### PR TITLE
fix smart comment syntax

### DIFF
--- a/src/db/migrations/13-backwards-compatible-views.ts
+++ b/src/db/migrations/13-backwards-compatible-views.ts
@@ -21,7 +21,7 @@ export const up = async (knex: Knex) => {
   // add comment to add fake fk constraints to view for postgraphile relation generation
   await knex.raw(
     `comment on view "erc721nfts_processedTracks" is
-    E'@foreignKey ("erc721NftId") references erc721nft (id)|@foreignKey ("processedTrackId") references "processedTracks" (id)';
+    E'@foreignKey ("processedTrackId") references "processedTracks" (id)\n@foreignKey ("erc721NftId") references erc721nft (id)';  
     `
   )
 


### PR DESCRIPTION
smart comment needs to use \n to chain commands not |