### PR TITLE
Fix artist naming

### DIFF
--- a/src/processors/default/processPlatformTracks/processPlatformTracks.ts
+++ b/src/processors/default/processPlatformTracks/processPlatformTracks.ts
@@ -107,7 +107,7 @@ const processorFunction = (platform: MusicPlatform) => async (nfts: NFT[], clien
   if (oldIds && oldIds.length !== 0) {
     await clients.db.delete(Table.processedTracks, oldIds);
   }
-  await clients.db.upsert(Table.artists, artists);
+  await clients.db.insert(Table.artists, artists, { ignoreConflict: 'id' });
   await clients.db.upsert(Table.artistProfiles, (allArtistProfiles as unknown as Record[]), ['artistId', 'platformId']);
   await clients.db.upsert(Table.processedTracks, mergedProcessedTracks);
   await clients.db.insert(Table.nfts_processedTracks, allJoins);


### PR DESCRIPTION
We currently upsert whenever we discover an artist, which will overwrite artist fields with whichever platform/nft we discover last. This PR makes us insert instead, so we prioritize using the fields from the first one we discover.

Neither is a great solution - I think eventually we want a better system for fields like artist name.
Using the first is good for artists that have done their first mint on curated platforms with good data like sound/catalog/noizd, but probably bad for artists that have done their first mint on zora with no additional metadata.

Using the first is also important so that slugs don't change.

The new zora PR breaks a few existing artist names by overwriting them, so i think this is the best fix to go with for now?

I also wasn't sure if changing from upsert to insert would have any unintended other side effects, but will think about it more. @Geimaj anything you can think of? and any other thoughts on this choice?

I think in a follow up PR we'll wanna at least change names that are addresses to ENS names, which will help, but that doesn't solve the more general problem.