### PR TITLE
Sound presale timing fix

### DIFF
--- a/src/db/migrations/36-add-nft-public-release-time.ts
+++ b/src/db/migrations/36-add-nft-public-release-time.ts
@@ -1,0 +1,16 @@
+import { Knex } from 'knex';
+
+import { Table } from '../db';
+import { updateViews } from '../migration-helpers';
+
+export const up = async (knex: Knex) => {
+  await knex.schema.alterTable(Table.nfts, table => {
+    table.datetime('publicReleaseTime', { precision: 3 });
+  })
+
+  await updateViews(knex);
+}
+
+export const down = async (knex: Knex) => {
+  throw new Error('nope');
+}

--- a/src/processors/default/createERC721NFTsFromTransfersProcessor.ts
+++ b/src/processors/default/createERC721NFTsFromTransfersProcessor.ts
@@ -67,7 +67,8 @@ const processorFunction = (contracts: NftFactory[]) =>
           tokenId,
           platformId: contract.platformId,
           owner: toAddress,
-          approved: contract.autoApprove
+          approved: contract.autoApprove,
+          publicReleaseTime: contract.typeMetadata?.other?.publicReleaseTime || undefined
         });
         nftsCollectorsChanges.push({ nftId: nftId, collectorId: toAddress, amount: 1 })
       }

--- a/src/triggers/missing.ts
+++ b/src/triggers/missing.ts
@@ -28,8 +28,8 @@ export const missingMetadataObject: Trigger<undefined> = async (clients) => {
 
 export const missingMetadataIPFSHash: Trigger<undefined> = async (clients) => {
   const nftQuery = `select * from "${Table.nfts}" n
-  left outer join "${Table.nftProcessErrors}" enpe 
-  on n.id = enpe."nftId" 
+  left outer join "${Table.nftProcessErrors}" enpe
+  on n.id = enpe."nftId"
   where enpe."metadataError" is null
   and n."metadataIPFSHash" is null
   and n.approved = true
@@ -45,7 +45,7 @@ export const NFTsWithoutTracks: (platformId: string, limit?: number) => Trigger<
     // and returns nfts where there is no corresponding track.
     // It also filters out error tracks so that nfts where we fail
     // to create a track are not repeated.
-    // Additionally we only return results for nfts that have 
+    // Additionally we only return results for nfts that have
     // been marked as approved.
     const nftQuery = `select n.* from "${Table.nfts}" as n
       LEFT OUTER JOIN "${Table.nfts_processedTracks}" as j
@@ -61,6 +61,7 @@ export const NFTsWithoutTracks: (platformId: string, limit?: number) => Trigger<
       n.metadata is not null AND
       n.approved = true
       and n."createdAtTime" is NOT NULL
+      and (n."publicReleaseTime" is NULL OR n."publicReleaseTime"::timestamp < now())
       ORDER BY n."createdAtTime"
       LIMIT ${limit}`
 

--- a/src/types/metaFactory.ts
+++ b/src/types/metaFactory.ts
@@ -87,7 +87,7 @@ export const MetaFactoryTypes: MetaFactoryTypes = {
     },
     creationEventToNftFactory: (event: any, autoApprove: boolean, factoryMetadata: any) => {
       const official = factoryMetadata.officialEditions.has(formatAddress(event.args!.soundEdition));
-      const publicTime = new Date(factoryMetadata.soundPublicTimes[formatAddress(event.args!.soundEdition)]);
+      const publicReleaseTime = new Date(factoryMetadata.soundPublicTimes[formatAddress(event.args!.soundEdition)]);
       return ({
         id: formatAddress(event.args!.soundEdition),
         platformId: official ? 'sound' : 'sound-protocol-v1',
@@ -98,7 +98,7 @@ export const MetaFactoryTypes: MetaFactoryTypes = {
         approved: official,
         typeMetadata: {
           other: {
-            publicTime
+            publicReleaseTime
           },
           overrides: {
             type: MusicPlatformType['multi-track-multiprint-contract'],

--- a/src/types/metaFactory.ts
+++ b/src/types/metaFactory.ts
@@ -74,18 +74,20 @@ export const MetaFactoryTypes: MetaFactoryTypes = {
     newContractCreatedEvent: 'SoundEditionCreated',
     metadataAPI: async (events, clients: Clients) => {
       const editionAddresses = new Set(events.map(event => formatAddress(event.args!.soundEdition)));
-      let soundOfficialContracts = new Set();
+      let soundPublicTimes: any;
       try {
-        soundOfficialContracts = await clients.sound.fetchContractAddresses();
+        soundPublicTimes = await clients.sound.fetchPublicTimes([...editionAddresses]);
       } catch {
         // If API Fails/is down, assume it's official
         return new Set([...editionAddresses]);
       }
-      const officialEditions = new Set([...editionAddresses].filter((address) => soundOfficialContracts.has(address)));
-      return officialEditions;
+      const publicAddresses = new Set(Object.keys(soundPublicTimes));
+      const officialEditions = new Set([...editionAddresses].filter((address) => publicAddresses.has(address)));
+      return { soundPublicTimes, officialEditions };
     },
     creationEventToNftFactory: (event: any, autoApprove: boolean, factoryMetadata: any) => {
-      const official = factoryMetadata.has(formatAddress(event.args!.soundEdition));
+      const official = factoryMetadata.officialEditions.has(formatAddress(event.args!.soundEdition));
+      const publicTime = new Date(factoryMetadata.soundPublicTimes[formatAddress(event.args!.soundEdition)]);
       return ({
         id: formatAddress(event.args!.soundEdition),
         platformId: official ? 'sound' : 'sound-protocol-v1',
@@ -95,6 +97,9 @@ export const MetaFactoryTypes: MetaFactoryTypes = {
         autoApprove: official,
         approved: official,
         typeMetadata: {
+          other: {
+            publicTime
+          },
           overrides: {
             type: MusicPlatformType['multi-track-multiprint-contract'],
             artist: {

--- a/src/types/nft.ts
+++ b/src/types/nft.ts
@@ -26,6 +26,7 @@ export type NFT = Record & {
   standard: NFTStandard;
   approved: boolean;
   burned: boolean;
+  publicReleaseTime?: Date;
 }
 
 export type ERC721Transfer = Record & {

--- a/src/types/nft.ts
+++ b/src/types/nft.ts
@@ -49,6 +49,7 @@ export enum NFTStandard {
 }
 
 export type TypeMetadata = {
+  other?: any
   overrides: {
     track?: Partial<ProcessedTrack>
     artist?: Partial<ArtistProfile>


### PR DESCRIPTION
Sound has issues with us releasing tracks during the nft presale period, so we're updating the indexer to wait until after the presale period has completed.

Tested this code by simulating a presale for oshi's recent track, using the below example queries:

```
select * from nft_factories where id='0xbfaa665c38a3dd9767f17ec8354b268db8296392';

update nft_factories SET "typeMetadata"=jsonb_set("typeMetadata"::jsonb, '{other}', '{"publicReleaseTime":"2022-10-07T14:17:14.942Z"}')
where id='0xbfaa665c38a3dd9767f17ec8354b268db8296392';

select "publicReleaseTime"::timestamp with time zone from raw_nfts
where id ILIKE '%0xbfaa665c38a3dd9767f17ec8354b268db8296392%';

select "publicReleaseTime", "publicReleaseTime"::timestamp with time zone,now(), "publicReleaseTime"::timestamp with time zone < now()  from raw_nfts
where id ILIKE '%0xbfaa665c38a3dd9767f17ec8354b268db8296392%'
and ("publicReleaseTime" is NULL OR "publicReleaseTime"::timestamp with time zone < now());

```

All working fine