### PR TITLE
turn off autoApprove

### DIFF
--- a/src/db/migrations/42-add-decent-editions.ts
+++ b/src/db/migrations/42-add-decent-editions.ts
@@ -17,7 +17,7 @@ const DECENT: MetaFactory = {
   platformId: DECENT_PLATFORM.id,
   contractType: MetaFactoryTypeName.decent,
   standard: NFTStandard.ERC721,
-  autoApprove: true,
+  autoApprove: false,
   startingBlock: '15691421'
 }
 


### PR DESCRIPTION
disable autoApprove to avoid indexing nfts that aren't music / haven't got complete metadata