### PR TITLE
Allow NFTFactory typeMetadata updates

### DIFF
--- a/src/seeds/validation.ts
+++ b/src/seeds/validation.ts
@@ -5,10 +5,9 @@ import { MusicPlatformType } from '../types/platform';
 
 import { AllApiOperations, CrdtEntities, MessagePayload } from './types';
 
-
 const PlatformValidKeys = ['id', 'name', 'type'];
 
-const NFTFactoryValidUpdateKeys = ['id', 'autoApprove', 'approved'];
+const NFTFactoryValidUpdateKeys = ['id', 'autoApprove', 'approved', 'typeMetadata'];
 const NFTFactoryValidUpsertKeys = ['id', 'startingBlock', 'platformId', 'contractType', 'standard', 'typeMetadata', 'autoApprove', 'approved'];
 const NFTFactoryMinUpsertKeys = NFTFactoryValidUpsertKeys.filter((key) => !['typeMetadata'].includes(key));
 


### PR DESCRIPTION
@puffo Needed this to fix recent hedsTape typeMetadata for their drop.

Can you think / double check there wasn't a strong reason why we didn't support this in the initial PR or risky edge cases this may introduce?