### PR TITLE
feat: upload avatars to IPFS

### DIFF
--- a/src/db/migrations/49-add-avatar-ipfs-hash.ts
+++ b/src/db/migrations/49-add-avatar-ipfs-hash.ts
@@ -1,0 +1,20 @@
+import {Knex} from 'knex';
+
+import {Table} from '../db';
+import { updateViews } from '../migration-helpers';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(Table.artistProfiles, table => {
+    table.string('avatarIPFSHash');
+  });
+
+  await updateViews(knex)
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable(Table.artistProfiles, table => {
+    table.dropColumn('avatarIPFSHash');
+  });
+
+  await updateViews(knex)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { ChainId } from './types/chain';
 import { MetaFactory, MetaFactoryTypeName } from './types/metaFactory';
 import { NftFactory, NFTStandard } from './types/nft';
 import { API_PLATFORMS, MusicPlatform } from './types/platform';
+import ipfsAvatarUploader from './processors/uploadAvatarToIpfs';
 
 const PROCESSORS = (
   nftFactories: NftFactory[],
@@ -95,6 +96,7 @@ const PROCESSORS = (
     ipfsFileSyncExistingPinsProcessor('lossyArtwork'),
     ipfsFileSyncExistingPinsProcessor('lossyAudio'),
     ipfsMimeTypeProcessor,
+    ipfsAvatarUploader
   ]
 };
 

--- a/src/processors/uploadAvatarToIpfs/IPFSUploadError.ts
+++ b/src/processors/uploadAvatarToIpfs/IPFSUploadError.ts
@@ -1,0 +1,16 @@
+export class IPFSUploadError extends Error {
+  readonly url: string;
+
+  constructor(message: string, url: string) {
+    super(message);
+
+    // 👇️ because we are extending a built-in class
+    Object.setPrototypeOf(this, IPFSUploadError.prototype);
+
+    this.url = url;
+  }
+
+  getErrorMessage() {
+    return 'Error when uploading file to IPFS: ' + this.message;
+  }
+}

--- a/src/processors/uploadAvatarToIpfs/IPFSUploadError.ts
+++ b/src/processors/uploadAvatarToIpfs/IPFSUploadError.ts
@@ -1,13 +1,17 @@
 export class IPFSUploadError extends Error {
+  readonly name = 'IPFSUploadError';
   readonly url: string;
 
   constructor(message: string, url: string) {
-    super(message);
+    super(getErrorMessage(message, url));
 
     // 👇️ because we are extending a built-in class
     Object.setPrototypeOf(this, IPFSUploadError.prototype);
 
     this.url = url;
   }
+}
 
+function getErrorMessage(url: string, message: string) {
+  return `Error when uploading file to IPFS at url "${url}": ${message}`;
 }

--- a/src/processors/uploadAvatarToIpfs/IPFSUploadError.ts
+++ b/src/processors/uploadAvatarToIpfs/IPFSUploadError.ts
@@ -10,7 +10,4 @@ export class IPFSUploadError extends Error {
     this.url = url;
   }
 
-  getErrorMessage() {
-    return 'Error when uploading file to IPFS: ' + this.message;
-  }
 }

--- a/src/processors/uploadAvatarToIpfs/index.ts
+++ b/src/processors/uploadAvatarToIpfs/index.ts
@@ -1,0 +1,1 @@
+export {ipfsAvatarUploader as default} from "./processor"

--- a/src/processors/uploadAvatarToIpfs/processor.ts
+++ b/src/processors/uploadAvatarToIpfs/processor.ts
@@ -118,7 +118,6 @@ const processorFunction = async (
 
   if (ipfsFileFailureUpdates.length > 0) console.log("IPFS file uploads failed: ", JSON.stringify(ipfsFileFailureUpdates))
 
-  // TODO: update rather than upsert (needs change to db client to accept multiple IDs)
   await clients.db.upsert(Table.artistProfiles, artistProfileUpdates, ['artistId', 'platformId']);
   await clients.db.upsert(Table.ipfsFiles, ipfsFileUpdates, 'url');
 };

--- a/src/processors/uploadAvatarToIpfs/processor.ts
+++ b/src/processors/uploadAvatarToIpfs/processor.ts
@@ -1,0 +1,130 @@
+import {extractHashFromURL, urlSource} from '../../clients/ipfs';
+import {Table} from '../../db/db';
+import {ArtistProfile} from '../../types/artist';
+import {IPFSFile} from '../../types/ipfsFile';
+import {Clients, Processor} from '../../types/processor';
+import {rollPromises} from '../../utils/rollingPromises';
+import {IPFSUploadError} from './IPFSUploadError';
+import {avatarsNotOnIpfs} from './trigger';
+
+type ProfileWithAvatarIpfsFile = ArtistProfile & Partial<IPFSFile>;
+
+type ArtistProfileId = {
+  artistId: string;
+  platformId: string;
+};
+
+type UploadedAvatarDetails = ArtistProfileId & {
+  cid: string;
+  avatarUrl: string;
+};
+
+const extractArtistProfileId = (
+  profileWithFile: ProfileWithAvatarIpfsFile,
+): ArtistProfileId => ({
+  artistId: profileWithFile.artistId,
+  platformId: profileWithFile.platformId,
+});
+
+const uploadAvatar = async (
+  profileWithFile: ProfileWithAvatarIpfsFile,
+  clients: Clients,
+): Promise<UploadedAvatarDetails> => {
+  console.log('uploadAvatarToIpfs:: uploading ', profileWithFile.avatarUrl);
+
+  if (profileWithFile.avatarUrl == null) {
+    throw new Error(`Error uploading avatar: the URL to upload is null!`);
+  }
+
+  // Check if this file is already on IPFS -- if so, we don't need to upload it ourselves,
+  // just to record its hash in the DB.
+  const preexistingIpfsHash = extractHashFromURL(profileWithFile.avatarUrl);
+  if (preexistingIpfsHash) {
+    // Return everything that is needed to update both DB entries: artist profile, and IPFS file
+    return {
+      ...extractArtistProfileId(profileWithFile),
+      avatarUrl: profileWithFile.avatarUrl,
+      cid: preexistingIpfsHash,
+    };
+  }
+
+  try {
+    const file = await clients.ipfs.client.add(
+      urlSource(profileWithFile.avatarUrl),
+      {
+        pin: false,
+        timeout: parseInt(process.env.IPFS_API_TIMEOUT!),
+      },
+    );
+
+    // Return everything that is needed to update both records: artist profile, and IPFS file
+    return {
+      ...extractArtistProfileId(profileWithFile),
+      avatarUrl: profileWithFile.avatarUrl,
+      cid: file.cid.toString(),
+    };
+  } catch (e: any) {
+    throw new IPFSUploadError(e.message, profileWithFile.avatarUrl);
+  }
+};
+
+/**
+ * Adds avatar images for artist profiles to IPFS. Saves the CID of these newly-uploaded avatar images to the database as avatarIPFSHash.
+ * @param artistProfilesWithFiles
+ * @param clients
+ */
+const processorFunction = async (
+  artistProfilesWithFiles: ProfileWithAvatarIpfsFile[],
+  clients: Clients,
+) => {
+  const results = await rollPromises<
+    ProfileWithAvatarIpfsFile,
+    UploadedAvatarDetails,
+    IPFSUploadError
+  >(
+    artistProfilesWithFiles,
+    profileIpfsFile => uploadAvatar(profileIpfsFile, clients),
+    300,
+    10000,
+  );
+
+  const uploadedAvatarDetails = results
+    .filter(result => !result.isError)
+    .map(result => result.response) as UploadedAvatarDetails[];
+  // We need to assert this type above because TypeScript isn't smart enough to know that this
+  // filters out all error responses
+
+  const artistProfileUpdates = uploadedAvatarDetails.map(
+    ({artistId, platformId, cid}) => ({
+      artistId,
+      platformId,
+      avatarIPFSHash: cid,
+    }),
+  );
+
+  const ipfsFileSuccessUpdates = uploadedAvatarDetails.map(
+    ({avatarUrl, cid}) => ({url: avatarUrl, cid}),
+  );
+
+  const ipfsFileFailureUpdates = results
+    .filter(result => result.isError)
+    .map(result => result.error as IPFSUploadError)
+    .map(error => ({url: error.url, error: error.message}));
+
+  const ipfsFileUpdates = [
+    ...ipfsFileSuccessUpdates,
+    ...ipfsFileFailureUpdates,
+  ];
+
+  if (ipfsFileFailureUpdates.length > 0) console.log("IPFS file uploads failed: ", JSON.stringify(ipfsFileFailureUpdates))
+
+  // TODO: update rather than upsert (needs change to db client to accept multiple IDs)
+  await clients.db.upsert(Table.artistProfiles, artistProfileUpdates, ['artistId', 'platformId']);
+  await clients.db.upsert(Table.ipfsFiles, ipfsFileUpdates, 'url');
+};
+
+export const ipfsAvatarUploader: Processor = {
+  name: 'ipfsAvatarUploader',
+  trigger: avatarsNotOnIpfs,
+  processorFunction,
+};

--- a/src/processors/uploadAvatarToIpfs/trigger.ts
+++ b/src/processors/uploadAvatarToIpfs/trigger.ts
@@ -1,0 +1,22 @@
+import { extractHashFromURL } from '../../clients/ipfs';
+import { Table } from '../../db/db';
+import { missingMetadataIPFSHash } from '../../triggers/missing';
+import { getMetadataURL } from '../../types/metadata';
+import { Clients, Processor } from '../../types/processor';
+import { Trigger } from '../../types/trigger';
+
+export const avatarsNotOnIpfs: Trigger<undefined> = async (clients: Clients) => {
+  const query = `select * from "${Table.artistProfiles}" as t
+      left outer join "${Table.ipfsFiles}" i
+      on t."avatarUrl" = i.url
+      where "avatarIPFSHash" is null
+      and "avatarUrl" is not null
+      and i.error is null
+      LIMIT ${process.env.IPFS_UPLOAD_BATCH_SIZE || process.env.QUERY_TRIGGER_BATCH_SIZE!}`
+
+  const artistProfilesWithFiles = (await clients.db.rawSQL(
+    query
+  )).rows
+
+  return artistProfilesWithFiles
+};

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -14,6 +14,7 @@ export type ArtistProfile = TimeField & {
   platformId: string;
   avatarUrl?: string;
   websiteUrl?: string;
+  avatarIPFSHash?: string;
 }
 
 export const mapArtist = (artistProfile: ArtistProfile): Artist => {


### PR DESCRIPTION
Adds a processor to upload artist profiles' avatars to IPFS.

Caveat: uploaded files will not be pinned. We need to update the IPFS pinner processor because it currently only looks at the `processedTracks` table  (in `src/processors/default/ipfsPinner.ts`). It should look at the IPFS files table.

**Next steps**
- remove avatarIPFSHash column and instead only use entries in IPFS files table (will need to change trigger too)
- probably also want to update the view to join on this table
- use error processor for retries

