### PR TITLE
Reindex relics tracks

### DIFF
--- a/src/constants/artistIntegrations.ts
+++ b/src/constants/artistIntegrations.ts
@@ -1,7 +1,7 @@
 
 import { formatAddress } from '../types/address';
 import { ChainId } from '../types/chain';
-import { TitleExtractorTypes, IdExtractorTypes, ArtistIdExtractorTypes, ArtistNameExtractorTypes, WebsiteUrlExtractorTypes, ArtworkUrlExtractorTypes, AudioUrlExtractorTypes } from '../types/fieldExtractor';
+import { TitleExtractorTypes, IdExtractorTypes, ArtistIdExtractorTypes, ArtistNameExtractorTypes, WebsiteUrlExtractorTypes, AudioUrlExtractorTypes } from '../types/fieldExtractor';
 import { MetaFactory, MetaFactoryTypeName } from '../types/metaFactory';
 import { NftFactory, NFTContractTypeName, NFTStandard } from '../types/nft';
 import { MusicPlatform, MusicPlatformType } from '../types/platform';
@@ -632,7 +632,7 @@ const RELICS_YXZ_PLATFORM: MusicPlatform = {
   name: 'RELICS',
 }
 
-const RELICS_SEASON_1_FACTORY: NftFactory = {
+export const RELICS_SEASON_1_FACTORY: NftFactory = {
   id: '0x441C1266E6fb13C38c2752eab0D11A99905FFef4',
   address: formatAddress('0x441C1266E6fb13C38c2752eab0D11A99905FFef4'),
   platformId: RELICS_YXZ_PLATFORM.id,
@@ -649,14 +649,12 @@ const RELICS_SEASON_1_FACTORY: NftFactory = {
       },
       track: {
         websiteUrl: 'https://relics.xyz',
-        lossyArtworkURL: 'https://web3-music-pipeline.mypinata.cloud/ipfs/QmSRN9HKXiziZzvkWrPG92UUHYiDKSZhfrFKf42EkniZVt',
       },
       type: MusicPlatformType['multi-track-multiprint-contract'],
       extractor: {
         id: IdExtractorTypes.USE_TITLE_EXTRACTOR,
         title: TitleExtractorTypes.METADATA_NAME_WITHOUT_TRAILING_INFO,
         audioUrl: AudioUrlExtractorTypes.ATTRIBUTES_TRAIT_AUDIO,
-        artworkUrl: ArtworkUrlExtractorTypes.USE_ARTWORK_URL_OVERRIDE,
         artistName: ArtistNameExtractorTypes.ATTRIBUTES_TRAIT_MUSICIAN,
         artistId: ArtistIdExtractorTypes.USE_PLATFORM_AND_ARTIST_NAME,
       }

--- a/src/db/migrations/50-adjust-relics-data.ts
+++ b/src/db/migrations/50-adjust-relics-data.ts
@@ -22,9 +22,6 @@ export const up = async (knex: Knex) => {
   // remove relics tracks
   await knex(Table.processedTracks).where({ platformId: 'relics' }).del()
 
-  // remove nftsProcessedTracks join
-  await knex(Table.nfts_processedTracks).whereIn('processedTrackId', tracks.map((track) => track.id)).del()
-
   // remove ipfsFiles
   if (artworkCids.length > 0) {
     await knex(Table.ipfsFiles).whereIn('cid', artworkCids).del()
@@ -33,11 +30,6 @@ export const up = async (knex: Knex) => {
   // remove ipfsPins
   if (artworkUrls.length > 0) {
     await knex(Table.ipfsPins).whereIn('id', artworkCids).del()
-  }
-
-  // remove ipfsFilesUrls
-  if (artworkUrls.length > 0) {
-    await knex(Table.ipfsFilesUrls).whereIn('url', artworkUrls).del()
   }
 
   const factories: any[] = [RELICS_SEASON_1_FACTORY].map((factory) => ({

--- a/src/db/migrations/50-adjust-relics-data.ts
+++ b/src/db/migrations/50-adjust-relics-data.ts
@@ -1,0 +1,54 @@
+import { Knex } from 'knex';
+import _ from 'lodash';
+
+import { RELICS_SEASON_1_FACTORY } from '../../constants/artistIntegrations';
+import { CrdtOperation } from '../../types/message';
+import { Table } from '../db';
+
+export const up = async (knex: Knex) => {
+  console.log('Removing RELICS season 1 data for reindexing');
+  const tracks = await knex(Table.processedTracks).where({ platformId: 'relics' })
+  console.log('# of tracks:');
+  console.log(tracks.length);
+
+  const artworkCids = _.compact(_.uniq(tracks.map((track) => track.lossyArtworkIPFSHash)));
+  const artworkUrls = _.compact(_.uniq(tracks.map((track) => track.lossyArtworkUrl)));
+
+  console.log('# of cids:');
+  console.log(artworkCids.length);
+  console.log('# of urls:');
+  console.log(artworkUrls.length);
+
+  // remove relics tracks
+  await knex(Table.processedTracks).where({ platformId: 'relics' }).del()
+
+  // remove nftsProcessedTracks join
+  await knex(Table.nfts_processedTracks).whereIn('processedTrackId', tracks.map((track) => track.id)).del()
+
+  // remove ipfsFiles
+  if (artworkCids.length > 0) {
+    await knex(Table.ipfsFiles).whereIn('cid', artworkCids).del()
+  }
+
+  // remove ipfsPins
+  if (artworkUrls.length > 0) {
+    await knex(Table.ipfsPins).whereIn('id', artworkCids).del()
+  }
+
+  // remove ipfsFilesUrls
+  if (artworkUrls.length > 0) {
+    await knex(Table.ipfsFilesUrls).whereIn('url', artworkUrls).del()
+  }
+
+  const factories: any[] = [RELICS_SEASON_1_FACTORY].map((factory) => ({
+    timestamp: new Date(),
+    table: Table.nftFactories,
+    data: factory,
+    operation: CrdtOperation.UPSERT,
+  }))
+  await knex(Table.seeds).insert(factories)
+}
+
+export const down = async (knex: Knex) => {
+  // No Operation
+}


### PR DESCRIPTION
Quick solution to allow spindexer to reindex RELICS tracks.

Also used as a POC for video / gif support on the track page.

---

Confirmed that reindex happens successfully and processedTrack is generated as per restrictions in SPI-774, and the resolved `lossyArtworkMimeType` is `video/mp4`.